### PR TITLE
Fix pgsql support with default django uuid field

### DIFF
--- a/openduty/models.py
+++ b/openduty/models.py
@@ -67,7 +67,7 @@ class Service(models.Model):
     Incidents are representations of a malfunction in the system.
     """
     name = models.CharField(max_length=80, unique=True)
-    id = UUIDField(primary_key=True, auto=True)
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4)
     retry = models.IntegerField(blank=True, null=True)
     policy = models.ForeignKey(SchedulePolicy, blank=True, null=True)
     escalate_after = models.IntegerField(blank=True, null=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ django-annoying==0.8.2
 django-auth-ldap==1.2.6
 django-celery==3.1.16
 django-scheduler==0.7.5
-django-uuidfield==0.5.0
 djangorestframework==3.1.3
 django-tables2-simplefilter==0.1
 django-tables2==1.0.4


### PR DESCRIPTION
Use default uuid model instead of django-uuid lib.